### PR TITLE
Fallback for empty search term

### DIFF
--- a/src/components/TheNounLookup.vue
+++ b/src/components/TheNounLookup.vue
@@ -82,6 +82,9 @@ onMounted(loadPreviousLookup)
                 <p class="mb-2">means <span class="accent-text">{{ english }}</span> (EN) and is</p>
                 <div class="accent subtitle gender" v-bind:class="matches[0].gender">{{ matches[0].gender }}</div>
               </div>
+              <div v-if="searchTerm.trim().length === 0">
+                <p>Enter a french noun.</p>
+              </div>
               <div v-else>
                 <TheNotFoundNotice :word="searchTerm" />
               </div>


### PR DESCRIPTION
# Overview

![image](https://github.com/ddikman/genre-substantif/assets/8461739/a4a6c13e-d5f9-40bc-bef5-fa4f87b24591)

Fixes so that when there is no search term, a message is shown instead of trying to look-up an empty searchTerm.