### PR TITLE
Fixed condition for missing words

### DIFF
--- a/src/components/TheNounLookup.vue
+++ b/src/components/TheNounLookup.vue
@@ -82,7 +82,7 @@ onMounted(loadPreviousLookup)
                 <p class="mb-2">means <span class="accent-text">{{ english }}</span> (EN) and is</p>
                 <div class="accent subtitle gender" v-bind:class="matches[0].gender">{{ matches[0].gender }}</div>
               </div>
-              <div v-if="searchTerm.trim().length === 0">
+              <div v-else-if="searchTerm.trim().length === 0">
                 <p>Enter a french noun.</p>
               </div>
               <div v-else>


### PR DESCRIPTION
Should fix this case

![image](https://github.com/ddikman/genre-substantif/assets/8461739/abd1033c-fd59-4148-86c4-aecc31c96ec9)

creds to @emesterhazy for finding it