### PR TITLE
Fix incorrect feminine form of etudiant

### DIFF
--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -22624,7 +22624,7 @@ export const dictionary: DictionaryWord[] = [
     "gen": "f"
   },
   {
-    "fr": "étudiant",
+    "fr": "étudiante",
     "en": "student",
     "gen": "f"
   },


### PR DESCRIPTION
Changed the feminine form from 'étudiant' to 'étudiante' in the dictionary. This fixes issue #18 where the incorrect feminine form was being displayed.